### PR TITLE
Ensure demo preconditions are met

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ The following sections describe the steps necessary to prepare your machine for 
 First of all, you'll need to install the [JCliff Ansible collection](https://github.com/wildfly-extras/ansible_collections_jcliff). Clone the project and run the following command line:
 
     $ cd ansible_collections_jcliff/
-    $ ansible-collection build .
+    $ ansible-galaxy collection build .
 
-This will produce a zipfile named redhat-jcliff-1.0.0.tgz. Install this new module for Ansible on the system running the automation tool:
+This will produce a zipfile named redhat-jcliff-0.0.5.tgz. Install this new module for Ansible on the system running the automation tool:
 
-    $ ansible-galaxy collection install path/to/redhat-jcliff-1.0.0.tgz.
+    $ ansible-galaxy collection install path/to/redhat-jcliff-0.0.5.tgz.
 
 ### Ansible Inventory
 

--- a/playbooks/demo.yml
+++ b/playbooks/demo.yml
@@ -1,4 +1,5 @@
 ---
+- import_playbook: preconds.yml
 # Keycloak Playbook
 - import_playbook: keycloak.yml
 

--- a/playbooks/preconds.yml
+++ b/playbooks/preconds.yml
@@ -1,0 +1,17 @@
+---
+- name: Playbook to validate host met the preconditions
+  hosts: wildfly
+  tasks:
+
+    - assert:
+        that:
+          - ansible_distribution is defined
+          - ansible_distribution == "RedHat"
+          - ansible_distribution_version is defined
+          - ansible_distribution_version == "8.4"
+          - ansible_version is defined
+          - ansible_version.string is version('2.9','>')
+          - ansible_python_version is defined
+          - ansible_python_version is version('3.6','>')
+        quiet: true
+        fail_msg: "This demo has been built for RHEL 8.4 using Ansible 2.9 running on Python 3"


### PR DESCRIPTION
@sabre1041 I've again ran into issue with the demo today. While the demo run fine in my docker container running Ansible 2.9 with Python3 it fails on a system using python 2.7.5  (The powershell error, the one where Ansible try to run powershell on Linux, appears, while it does not on my local system). 

So I've decided to add a playbook to check that the system targeted does meet the prereqs for the demo.

FYI, here is the config of the system that works (my podman container) :
```
[root@425dd4395618 work]# ansible-playbook --version
ansible-playbook 2.9.22
  config file = /work/ansible.cfg
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.6/site-packages/ansible
  executable location = /usr/bin/ansible-playbook
  python version = 3.6.8 (default, Mar 18 2021, 08:58:41) [GCC 8.4.1 20200928 (Red Hat 8.4.1-1)]
[root@425dd4395618 work]# cat /etc/redhat-release 
Red Hat Enterprise Linux release 8.4 (Ootpa)
```
