### PR TITLE
wfly: wait for cli port before querying

### DIFF
--- a/roles/3trains_wildfly/tasks/keycloak-extension-install.yml
+++ b/roles/3trains_wildfly/tasks/keycloak-extension-install.yml
@@ -12,6 +12,14 @@
 - set_fact:
     jboss_cli: "{{ wildfly.home }}/bin/jboss-cli.sh -c --controller=localhost:{{ wildfly_instance_port }}"
 
+- name: Wait for wildfly port
+  wait_for:
+    port: "{{wildfly_instance_port|int}}"
+    host: localhost
+    connect_timeout: 3
+    delay: 5
+    timeout: 60
+        
 - block:
     - name: Check if Keycloak extensions installed
       command: >


### PR DESCRIPTION
The check for the keycloak extension (followed eventually by
installation) is run only a few secs after systemctl returns
from the service startup, ending with a connection refused error.
Our check is confused and thinks the err retcode means
the extension is not installed, and proceeds with installation
in the next step (eventually causing another error for duplicate
installation if the port is now available and keycloak config
is present).

Lets wait for the port
