### PR TITLE
Implement scenario with rhsso in ha and remote caches on jdg server

### DIFF
--- a/ansible-demo-podman.sh
+++ b/ansible-demo-podman.sh
@@ -3,14 +3,10 @@
 # create dnsname enabled podman network
 # podman network create 3trains
 # { "capabilities": { "aliases": true }, "domainName": "dns.podman", "type": "dnsname" }
-podman network reload --all
-podman run --name=jbcs-0     --network 3trains --systemd=true  --workdir /work -v $(pwd):/work:rw  -dit localhost/ubi8/ubi-ansible-3trains-demo:latest /sbin/init
-podman run --name=jdg-0      --network 3trains --systemd=true  --workdir /work -v $(pwd):/work:rw  -dit localhost/ubi8/ubi-ansible-3trains-demo:latest /sbin/init
-podman run --name=keycloak-0 --network 3trains --systemd=true  --workdir /work -v $(pwd):/work:rw  -dit localhost/ubi8/ubi-ansible-3trains-demo:latest /sbin/init
-podman run --name=pgsql-0    --network 3trains --systemd=true  --workdir /work -v $(pwd):/work:rw  -dit localhost/ubi8/ubi-ansible-3trains-demo:latest /sbin/init
-podman run --name=wfly-1     --network 3trains --systemd=true  --workdir /work -v $(pwd):/work:rw  -dit localhost/ubi8/ubi-ansible-3trains-demo:latest /sbin/init
-podman run --name=wfly-2     --network 3trains --systemd=true  --workdir /work -v $(pwd):/work:rw  -dit localhost/ubi8/ubi-ansible-3trains-demo:latest /sbin/init
-podman run --name=wfly-3     --network 3trains --systemd=true  --workdir /work -v $(pwd):/work:rw  -dit localhost/ubi8/ubi-ansible-3trains-demo:latest /sbin/init
+podman network reload --all 2>&1 >/dev/null
+while read node ; do
+    echo -n "Starting container ${node}.... "
+    podman run --name=${node} --network 3trains --systemd=true  --workdir /work -v $(pwd):/work:rw  -dit localhost/ubi8/ubi-ansible-3trains-demo:latest /sbin/init
+done < <( ansible-inventory -i inventory/demo --list | jq -r "._meta.hostvars | keys[]")
+podman network reload --all 2>&1 >/dev/null
 ANSIBLE_CONFIG=podman/ansible-podman.cfg ansible-playbook -e @rhn-creds.yml -i inventory/demo playbooks/demo.yml "$@"
-
-

--- a/collections/requirements.yml
+++ b/collections/requirements.yml
@@ -1,7 +1,7 @@
 ---
 collections:
   - name: middleware_automation.jcliff
-    version: ">=0.0.17"
+    version: ">=0.0.19"
   - name: middleware_automation.redhat_csp_download
     version: ">=1.2.1"
   - name: community.general

--- a/inventory/demo
+++ b/inventory/demo
@@ -12,7 +12,7 @@ wfly-3
 keycloak-0
 
 [jdg]
-jdg-0
+jdg-1
 
 [pgsql]
 pgsql-0

--- a/playbooks/demo.yml
+++ b/playbooks/demo.yml
@@ -4,6 +4,9 @@
 # JBoss Core Services (Apache HTTPD)
 - import_playbook: jbcs.yml
 
+# Datagrid Playbook
+- import_playbook: jdg.yml
+
 # Keycloak Playbook
 - import_playbook: keycloak.yml
 

--- a/roles/3trains_jdg/defaults/main.yml
+++ b/roles/3trains_jdg/defaults/main.yml
@@ -31,7 +31,7 @@ jdg:
   service:
     name: "{{ override_jdg_service_name | default('jdg') }}"
   users:
-    - { name: 'rpelisse', password: 'itsme', roles: 'supervisor' }
+    - { name: 'supervisor', password: 'itsme', roles: 'supervisor' }
 
 jdg_keycloak_cache:
   enabled: True
@@ -42,3 +42,4 @@ jdg_keycloak_cache:
     - offlineClientSessions
     - loginFailures
     - actionTokens
+    - work

--- a/roles/3trains_jdg/defaults/main.yml
+++ b/roles/3trains_jdg/defaults/main.yml
@@ -11,11 +11,21 @@ jdg:
     template: "{{ override_jdg_config_template | default('templates/infinispan.xml.j2') }}"
     users: "{{ override_jdg_config_users_properties | default('users.properties') }}"
     groups: "{{ override_jdg_config_group_properties | default('groups.properties') }}"
-  user: 
+  user:
     name: "{{ override_jdg_user | default('jdg') }}"
-  group: 
+  group:
     name: "{{ override_jdg_group | default('jdg') }}"
   service:
     name: "{{ override_jdg_service_name | default('jdg') }}"
   users:
-    - { name: 'rpelisse', password: 'itsme', roles: 'supervisor' } 
+    - { name: 'rpelisse', password: 'itsme', roles: 'supervisor' }
+
+jdg_keycloak_cache:
+  enabled: True
+  caches:
+    - sessions
+    - offlineSessions
+    - clientSessions
+    - offlineClientSessions
+    - loginFailures
+    - actionTokens

--- a/roles/3trains_jdg/defaults/main.yml
+++ b/roles/3trains_jdg/defaults/main.yml
@@ -1,9 +1,22 @@
 ---
+# Red Hat JDG specific config
 jdg_version: "8.2.0"
 jdg_default_installation_path: "/opt/redhat-datagrid-{{ jdg_version }}-server/"
+jdg_bundle: "jdg-{{ jdg_version }}.zip"
+jdg_download_url: 'https://access.redhat.com/jbossnetwork/restricted/softwareDownload.html?softwareId='
+
+# Infinispan specific config
+infinispan_version: "12.1.7.Final"
+infinispan_bundle: "infinispan-server-{{ infinispan_version }}.zip"
+infinispan_download_url: "https://downloads.jboss.org/infinispan/{{ infinispan_version }}/{{ infinispan_bundle }}"
+infinispan_installation_path: "/opt/infinispan-server-{{ infinispan_version }}/"
+
+# common config for datagrid/infinispan service
+jdg_app_download_dir: "/opt/apps"
+jdg_enable: "{{ True if jdg_rhn_id is defined else False }}"
 jdg_healthcheck: yes
 jdg:
-  home: "{{ override_jdg_home | default(jdg_default_installation_path) }}"
+  home: "{{jdg_default_installation_path if jdg_rhn_id is defined else infinispan_installation_path }}"
   bind_addr: "{{ override_jdg_bind_addr | default('localhost') }}"
   port: "{{ override_jdg_port | default('11222') }}"
   config:

--- a/roles/3trains_jdg/tasks/download_from_rhn.yml
+++ b/roles/3trains_jdg/tasks/download_from_rhn.yml
@@ -1,0 +1,67 @@
+---
+- assert:
+    that:
+      - zipfile_dest is defined
+      - rhn_id_file is defined
+      - rhn_username is defined
+      - rhn_password is defined
+    quiet: true
+
+- set_fact:
+    rhn_download_url: "{{ jdg_download_url }}{{ rhn_id_file }}"
+
+- name: "Install zipfile from RHN: {{ rhn_download_url }}"
+  redhat_csp_download:
+    url: "{{ rhn_download_url }}"
+    dest: "{{ zipfile_dest }}"
+    username: "{{ rhn_username }}"
+    password: "{{ rhn_password }}"
+  no_log: "{{ omit_rhn_output | default(true) }}"
+  when:
+    - archive_path is defined
+    - archive_path.stat is defined
+    - not archive_path.stat.exists
+
+- stat:
+    path: "{{ zipfile_dest }}"
+  register: path_to_downloaded_artefact
+
+- block:
+    - file:
+        path: "{{ work_dir }}"
+        state: directory
+
+    - stat:
+        path: "{{ target_dir }}"
+      register: target_dir_state
+
+    - assert:
+        that:
+          - target_dir_state is defined
+          - target_dir_state.stat is defined
+        fail_msg: "Directory layout for {{ target_dir }} is invalid."
+        quiet: true
+
+    - name: "Decompress {{ zipfile_dest }} into {{ work_dir }} (results in {{ target_dir }}."
+      unarchive:
+        src: "{{ zipfile_dest }}"
+        dest: "{{ work_dir }}"
+        owner: "{{ jdg.user.name }}"
+        group: "{{ jdg.group.name }}"
+        remote_src: yes
+        creates: "{{ target_dir }}"
+      when:
+        - not target_dir_state.stat.exists
+      notify:
+        - restart jdg
+
+    - debug:
+        msg: "{{ target_dir }} already exists, skipping decompressing {{ zipfile_dest }}"
+      when:
+        - target_dir_state.stat.exists
+  when:
+    - path_to_downloaded_artefact is defined
+    - path_to_downloaded_artefact.stat is defined
+    - path_to_downloaded_artefact.stat.exists
+    - target_dir is defined
+    - work_dir is defined

--- a/roles/3trains_jdg/tasks/firewalld.yml
+++ b/roles/3trains_jdg/tasks/firewalld.yml
@@ -22,3 +22,4 @@
     immediate: yes
   loop:
     - "{{ jdg.port }}/tcp"
+    - 7800/tcp

--- a/roles/3trains_jdg/tasks/firewalld.yml
+++ b/roles/3trains_jdg/tasks/firewalld.yml
@@ -1,0 +1,24 @@
+---
+- name: "Ensures required package firewalld are installed"
+  include_role:
+    name: 3trains_fastpackages
+  vars:
+    packages_list:
+      - firewalld
+
+- name: enable and start the firewalld service
+  become: yes
+  systemd:
+    name: firewalld
+    enabled: yes
+    state: started
+
+- name: configure firewall for jdg ports
+  become: yes
+  firewalld:
+    port: "{{ item }}"
+    permanent: true
+    state: enabled
+    immediate: yes
+  loop:
+    - "{{ jdg.port }}/tcp"

--- a/roles/3trains_jdg/tasks/install.yml
+++ b/roles/3trains_jdg/tasks/install.yml
@@ -1,0 +1,62 @@
+- block:
+    - set_fact:
+        archive: "{{ jdg_app_download_dir }}/{{ infinispan_bundle }}"
+
+    - stat:
+        path: "{{ archive }}"
+      register: archive_path
+
+    - name: download infinispan archive to target
+      get_url:
+        url: "{{ infinispan_download_url }}"
+        dest: "{{ archive }}"
+        owner: "{{ jdg.user.name }}"
+        group: "{{ jdg.group.name }}"
+      when:
+        - archive_path is defined
+        - archive_path.stat is defined
+        - not archive_path.stat.exists
+
+    - name: extract infinispan archive on target
+      unarchive:
+        remote_src: yes
+        src: "{{ archive }}"
+        dest: "/opt"
+        creates: "{{ infinispan_installation_path }}"
+        owner: "{{ jdg.user.name }}"
+        group: "{{ jdg.group.name }}"
+      notify:
+        - restart jdg
+  become: yes
+  when: not jdg_enable
+
+- block:
+    - assert:
+        that:
+          - jdg_rhn_id is defined
+        quiet: true
+        fail_msg: "Can't install Red Hat Datagrid without RHN ID."
+
+    - set_fact:
+        archive: "{{ jdg_app_download_dir }}/{{ jdg_bundle }}"
+
+    - stat:
+        path: "{{ archive }}"
+      register: archive_path
+
+    - include_tasks: download_from_rhn.yml
+      vars:
+        rhn_id_file: "{{ jdg_rhn_id }}"
+        zipfile_dest: "{{ archive }}"
+        work_dir: "/opt"
+        target_dir: "{{ jdg_default_installation_path }}"
+  become: yes
+  when: jdg_enable
+
+- name: "Reown installation directory to {{ jdg.user.name }}"
+  file:
+    path: "{{ jdg.home }}"
+    owner: "{{ jdg.user.name }}"
+    group: "{{ jdg.group.name }}"
+    recurse: true
+  changed_when: false

--- a/roles/3trains_jdg/tasks/main.yml
+++ b/roles/3trains_jdg/tasks/main.yml
@@ -12,59 +12,29 @@
 
 - include_tasks: prereqs.yml
 
-- group:
+- name: "Create group {{ jdg.group.name }}"
+  group:
     name: "{{ jdg.group.name }}"
     state: present
     gid: "{{ jdg.group.id | default(omit) }}"
 
-- user:
+- name: "Create user {{ jdg.user.name }}"
+  user:
     name: "{{ jdg.user.name }}"
     state: present
     uid: "{{ jdg.user.id | default(omit) }}"
 
-- set_fact:
-    zip_file_repo: /opt/apps
-
-- set_fact:
-    jdg_src: "{{ zip_file_repo }}/jdg-{{ jdg_version }}.zip"
-
-- file:
-    path: "{{ zip_file_repo }}"
+- name: "Create download directory"
+  file:
+    path: "{{ jdg_app_download_dir }}"
     state: directory
 
-- name: Download JBoss Core Services from CSP
-  redhat_csp_download:
-    url: "https://access.redhat.com/jbossnetwork/restricted/softwareDownload.html?softwareId=98151"
-    dest: "{{ jdg_src }}"
-    username: "{{ rhn_username }}"
-    password: "{{ rhn_password }}"
-  when:
-    - not jdg_installed is defined
-
-- stat:
-    path: "/opt/redhat-datagrid-8.2.0-server/"
-  register: jdg_home
-
-- debug:
-    msg: "{{ jdg_home }}"
-
-- name: Unarchive JDG
-  unarchive:
-    src: "{{ jdg_src }}"
-    remote_src: yes
-    dest: /opt
-    creates: "/opt/redhat-datagrid-8.2.0-server/server"
-  when:
-    - not jdg_home.stat.exists
-
-- file:
-    path: "{{ jdg.home }}"
-    owner: "{{ jdg.user.name }}"
-    group: "{{ jdg.group.name }}"
-    recurse: true
-  changed_when: false
+- include_tasks: tasks/install.yml
 
 - include_tasks: tasks/firewalld.yml
+
+- debug:
+    msg: "{{ 'Red Hat Datagrid' if jdg_rhn_id is defined else 'Infinispan' }} installed at path {{ jdg.home }}"
 
 - name: "Configure systemd unit file for JDG service"
   template:
@@ -77,6 +47,13 @@
   notify:
     - restart jdg
 
+- name: "Perform daemon-reload to ensure the changes on jdg service are picked up"
+  systemd:
+    daemon_reload: yes
+  when:
+    - jdg_daemon_reload is defined
+    - jdg_daemon_reload.changed
+
 - name: "Ensures JDG configuration is deployed: {{ jdg.config.name }}"
   template:
     src: "{{ jdg.config.template }}"
@@ -84,6 +61,7 @@
     owner: "{{ jdg.user.name }}"
     group: "{{ jdg.group.name }}"
     mode: 0644
+    backup: yes
   when:
     - jdg.config is defined
     - jdg.config.name is defined
@@ -96,13 +74,6 @@
   when:
     - jdg.users is defined
     - jdg.users | length > 0
-
-- name: "Perform daemon-reload to ensure the changes on jdg service are picked up"
-  systemd:
-    daemon_reload: yes
-  when:
-    - jdg_daemon_reload is defined
-    - jdg_daemon_reload.changed
 
 - name: Ensures JDG service is running and enabled
   systemd:

--- a/roles/3trains_jdg/tasks/main.yml
+++ b/roles/3trains_jdg/tasks/main.yml
@@ -81,6 +81,8 @@
     state: started
     enabled: yes
 
+- meta: flush_handlers
+
 - name: "Wait for all used ports to be open"
   wait_for:
     port: "{{ jdg.port }}"

--- a/roles/3trains_jdg/tasks/main.yml
+++ b/roles/3trains_jdg/tasks/main.yml
@@ -64,6 +64,7 @@
     recurse: true
   changed_when: false
 
+- include_tasks: tasks/firewalld.yml
 
 - name: "Configure systemd unit file for JDG service"
   template:
@@ -103,7 +104,7 @@
     - jdg_daemon_reload is defined
     - jdg_daemon_reload.changed
 
-- name: Ensures JDG service is running
+- name: Ensures JDG service is running and enabled
   systemd:
     name: jdg
     state: started
@@ -124,4 +125,3 @@
     jdg_password: "{{ jdg.users[0].password }}"
     cache:
       name: kitchensink_sql_cache
-

--- a/roles/3trains_jdg/tasks/prereqs.yml
+++ b/roles/3trains_jdg/tasks/prereqs.yml
@@ -7,17 +7,9 @@
     - procps-ng
     - initscripts
     - "{{ jvm_package | default('java-1.8.0-openjdk-devel') }}"
-    - firewalld
 
 - name: "Ensures required packages are installed"
   include_role:
     name: 3trains_fastpackages
   vars:
     packages_list: "{{ required_packages }}"
-
-- name: enable and start the firewalld service
-  become: yes
-  systemd:
-    name: firewalld
-    enabled: yes
-    state: started

--- a/roles/3trains_jdg/templates/infinispan.service.j2
+++ b/roles/3trains_jdg/templates/infinispan.service.j2
@@ -2,18 +2,18 @@
 # Modify environment properties in this script as appropriate.
 # Copy this script to the following location: /etc/systemd/system
 # Activate with 'systemctl daemon-reload'
-#               'systemctl start|enable infinispan'
+#               'systemctl start|enable jdg'
 
 [Unit]
 Description=Infinispan Server Service
 After=network.target
 
 [Service]
-Environment="INFINISPAN_HOME={{ jdg.home }}"
-#Environment="JAVA_HOME=/usr/java/jdk-11.0.8"
-ExecStart=/bin/bash -c "${INFINISPAN_HOME}/bin/server.sh -c {{ jdg.config.name }} -b {{ jdg.bind_addr }}"
-Type=simple
-User={{ jdg.user.name }}
+Environment="ISPN_PIDFILE=/run/jdg.pid"
+ExecStart=/bin/sh -c '{{ jdg.home }}/bin/server.sh -c {{ jdg.config.name }} -b {{ jdg.bind_addr }} &'
+Type=forking
+TimeoutSec=30
+PIDFile=/run/jdg.pid
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/3trains_jdg/templates/infinispan.xml.j2
+++ b/roles/3trains_jdg/templates/infinispan.xml.j2
@@ -28,8 +28,6 @@
    <server xmlns="urn:infinispan:server:12.1">
       <interfaces>
          <interface name="public">
-             <!--match-interface value="{{ ansible_default_ipv4.interface }}"/-->
-             <!--inet-address value="${infinispan.bind.address:127.0.0.1}"/-->
              <any-address/>
          </interface>
       </interfaces>

--- a/roles/3trains_jdg/templates/infinispan.xml.j2
+++ b/roles/3trains_jdg/templates/infinispan.xml.j2
@@ -16,9 +16,9 @@
 
 {% if jdg_keycloak_cache.enabled %}
     <!-- keycloak caches -->
-    <cache-container name="keycloak">
+    <cache-container name="keycloak" statistics="true">
 {% for keycloak_cache in jdg_keycloak_cache.caches %}
-      <replicated-cache name="{{ keycloak_cache }}" statistics="true" mode="SYNC" start="EAGER">
+      <replicated-cache name="{{ keycloak_cache }}" mode="SYNC">
         <transaction mode="NONE" locking="PESSIMISTIC"/>
         <locking acquire-timeout="0" />
       </replicated-cache>

--- a/roles/3trains_jdg/templates/infinispan.xml.j2
+++ b/roles/3trains_jdg/templates/infinispan.xml.j2
@@ -28,7 +28,9 @@
    <server xmlns="urn:infinispan:server:12.1">
       <interfaces>
          <interface name="public">
-            <inet-address value="${infinispan.bind.address:127.0.0.1}"/>
+             <!--match-interface value="{{ ansible_default_ipv4.interface }}"/-->
+             <!--inet-address value="${infinispan.bind.address:127.0.0.1}"/-->
+             <any-address/>
          </interface>
       </interfaces>
 
@@ -62,6 +64,7 @@
       </security>
 
       <endpoints socket-binding="default" security-realm="default">
+        <hotrod-connector name="hotrod"/>
         <rest-connector name="rest">
           <authentication mechanisms="DIGEST BASIC"/>
         </rest-connector>

--- a/roles/3trains_jdg/templates/infinispan.xml.j2
+++ b/roles/3trains_jdg/templates/infinispan.xml.j2
@@ -5,15 +5,26 @@
         xmlns="urn:infinispan:config:12.1"
         xmlns:server="urn:infinispan:server:12.1">
 
-   <cache-container name="default" statistics="true">
+    <cache-container name="default" statistics="true">
       <transport cluster="${infinispan.cluster.name:cluster}" stack="${infinispan.cluster.stack:tcp}" node-name="${infinispan.node.name:}"/>
       <security>
-	<authorization>
+        <authorization>
           <role name="supervisor" permissions="READ WRITE EXEC CREATE"/>
-	</authorization>
+	      </authorization>
       </security>
-   </cache-container>
+    </cache-container>
 
+{% if jdg_keycloak_cache.enabled %}
+    <!-- keycloak caches -->
+    <cache-container name="keycloak">
+{% for keycloak_cache in jdg_keycloak_cache.caches %}
+      <replicated-cache name="{{ keycloak_cache }}" statistics="true" mode="SYNC" start="EAGER">
+        <transaction mode="NONE" locking="PESSIMISTIC"/>
+        <locking acquire-timeout="0" />
+      </replicated-cache>
+{% endfor %}
+    </cache-container>
+{% endif %}
    <server xmlns="urn:infinispan:server:12.1">
       <interfaces>
          <interface name="public">
@@ -53,7 +64,7 @@
       <endpoints socket-binding="default" security-realm="default">
         <rest-connector name="rest">
           <authentication mechanisms="DIGEST BASIC"/>
-	</rest-connector>
+        </rest-connector>
       </endpoints>
    </server>
 </infinispan>

--- a/roles/3trains_keycloak/defaults/main.yml
+++ b/roles/3trains_keycloak/defaults/main.yml
@@ -77,3 +77,24 @@ keycloak_users:
       - client: "{{ keycloak_3trains_client_name }}"
         role: "{{ keycloak_3trains_user_role }}"
         realm: "{{ keycloak_realm }}"
+
+keycloak_remotecache:
+  enabled: True
+  username: supervisor
+  password: itsme
+  realm: default
+  server_name: jdg-0
+  trust_store_path:
+  trust_store_password: changeme
+
+keycloak_jdbc:
+  postgres:
+    enabled: True
+    driver_module_name: "org.postgresql"
+    driver_module_dir: "{{ keycloak_jboss_home }}/modules/org/postgresql/main"
+    driver_version: 9.4.1212
+    driver_jar_filename: "postgresql-9.4.1212.jar"
+    driver_jar_url: "https://repo.maven.apache.org/maven2/org/postgresql/postgresql/9.4.1212/postgresql-9.4.1212.jar"
+    connection_url: "jdbc:postgresql://pgsql-0:5432/keycloak"
+    db_user: "keycloak-user"
+    db_password: "keycloak-pass"

--- a/roles/3trains_keycloak/defaults/main.yml
+++ b/roles/3trains_keycloak/defaults/main.yml
@@ -78,8 +78,11 @@ keycloak_users:
         role: "{{ keycloak_3trains_user_role }}"
         realm: "{{ keycloak_realm }}"
 
+
+keycloak_ha_enabled: True
+
 keycloak_remotecache:
-  enabled: True
+  enabled: "{{ keycloak_ha_enabled }}"
   username: supervisor
   password: itsme
   realm: default
@@ -89,7 +92,7 @@ keycloak_remotecache:
 
 keycloak_jdbc:
   postgres:
-    enabled: True
+    enabled: "{{ keycloak_ha_enabled }}"
     driver_module_name: "org.postgresql"
     driver_module_dir: "{{ keycloak_jboss_home }}/modules/org/postgresql/main"
     driver_version: 9.4.1212

--- a/roles/3trains_keycloak/meta/main.yml
+++ b/roles/3trains_keycloak/meta/main.yml
@@ -53,3 +53,4 @@ dependencies: []
 
 collections:
   - middleware_automation.redhat_csp_download
+  - middleware_automation.jcliff

--- a/roles/3trains_keycloak/tasks/install.yml
+++ b/roles/3trains_keycloak/tasks/install.yml
@@ -107,6 +107,20 @@
   become: yes
   when: keycloak_rhsso_enable
 
+- name: "Install Postresql driver"
+  include_role:
+    name: wildfly_driver
+    tasks_from: jdbc_driver.yml
+  vars:
+      wildfly_user: "{{ keycloak_service_user }}"
+      jdbc_driver_module_dir: "{{ keycloak_jdbc.postgres.driver_module_dir }}"
+      jdbc_driver_version: "{{ keycloak_jdbc.postgres.driver_version }}"
+      jdbc_driver_jar_filename: "{{ keycloak_jdbc.postgres.driver_jar_filename }}"
+      jdbc_driver_jar_url: "{{ keycloak_jdbc.postgres.driver_jar_url }}"
+      jdbc_driver_jar_installation_path: "{{ keycloak_jdbc.postgres.driver_module_dir }}/{{ keycloak_jdbc.postgres.driver_jar_filename }}"
+      jdbc_driver_module_name: "{{ keycloak_jdbc.postgres.driver_module_name }}"
+  when: keycloak_jdbc.postgres.enabled
+
 - name: "Deploy Keycloak's standalone.xml"
   become: yes
   template:
@@ -114,3 +128,13 @@
     dest: "{{ keycloak_jboss_home }}/standalone/configuration/standalone.xml"
   notify:
     - restart keycloak
+  when: not keycloak_remotecache.enabled
+
+- name: "Deploy Keycloak's standalone.xml with remote cache store"
+  become: yes
+  template:
+    src: "{{ 'templates/standalone-rhsso-jdg.xml.j2' if keycloak_rhsso_enable else 'templates/standalone-jdg.xml.j2' }}"
+    dest: "{{ keycloak_jboss_home }}/standalone/configuration/standalone.xml"
+  notify:
+    - restart keycloak
+  when: keycloak_remotecache.enabled

--- a/roles/3trains_keycloak/tasks/main.yml
+++ b/roles/3trains_keycloak/tasks/main.yml
@@ -86,7 +86,7 @@
 
 - name: Manage User Roles
   include_tasks: manage_user_roles.yml
-  loop: "{{ keycloak_users }}"
+  loop: "{{ keycloak_users | flatten }}"
   loop_control:
     loop_var: user
-  when: "'client_roles' in user"
+  when: "{{ 'client_roles' in user }}"

--- a/roles/3trains_keycloak/tasks/main.yml
+++ b/roles/3trains_keycloak/tasks/main.yml
@@ -96,4 +96,4 @@
   loop: "{{ keycloak_users | flatten }}"
   loop_control:
     loop_var: user
-  when: "{{ 'client_roles' in user }}"
+  when: "'client_roles' in user"

--- a/roles/3trains_keycloak/tasks/main.yml
+++ b/roles/3trains_keycloak/tasks/main.yml
@@ -76,7 +76,14 @@
     web_origins: "{{ item.web_origins | default('+') }}"
     state: present
   register: create_client_result
-  loop: "{{ keycloak_clients }}"
+  loop: "{{ keycloak_clients | flatten }}"
+
+- name: Create 3trains client roles
+  include_tasks: manage_client_roles.yml
+  when: keycloak_rhsso_enable
+  loop: "{{ keycloak_clients | flatten }}"
+  loop_control:
+    loop_var: client
 
 - name: Manage Users
   include_tasks: manage_user.yml

--- a/roles/3trains_keycloak/tasks/manage_client_roles.yml
+++ b/roles/3trains_keycloak/tasks/manage_client_roles.yml
@@ -1,0 +1,12 @@
+- name: Create 3trains client roles
+  community.general.keycloak_role:
+    name: "{{ item }}"
+    realm: "{{ client.realm }}"
+    client_id: "{{ client.name }}"
+    auth_client_id: "{{ keycloak_auth_client }}"
+    auth_keycloak_url: "{{ keycloak_url }}/auth"
+    auth_realm: "{{ keycloak_auth_realm }}"
+    auth_username: "{{ keycloak_admin_user }}"
+    auth_password: "{{ keycloak_admin_password }}"
+    state: present
+  loop: "{{ client.roles | flatten }}"

--- a/roles/3trains_keycloak/tasks/manage_user_client_roles.yml
+++ b/roles/3trains_keycloak/tasks/manage_user_client_roles.yml
@@ -1,11 +1,10 @@
 ---
-
-- name: "Get Realm"
+- name: "Get Realm for role"
   uri:
     url: "{{ keycloak_url }}/auth/admin/realms/{{ client_role.realm }}"
     method: GET
     status_code:
-     - 200
+      - 200
     headers:
       Accept: "application/json"
       Authorization: "Bearer {{ keycloak_auth_response.json.access_token }}"
@@ -16,7 +15,7 @@
     url: "{{ keycloak_url }}/auth/admin/realms/{{ client_role.realm }}/users/{{ (keycloak_user.json | first).id }}/role-mappings/clients/{{ (create_client_result.results | selectattr('end_state.clientId', 'equalto', client_role.client) | list | first).end_state.id }}/available"
     method: GET
     status_code:
-     - 200
+      - 200
     headers:
       Accept: "application/json"
       Authorization: "Bearer {{ keycloak_auth_response.json.access_token }}"
@@ -32,10 +31,10 @@
         containerId: "{{ item.containerId }}"
         name: "{{ item.name }}"
         composite: "{{ item.composite }}"
-    validate_certs: no
+    validate_certs: False
     body_format: json
     headers:
       Authorization: "Bearer {{ keycloak_auth_response.json.access_token }}"
     status_code: 204
-  loop: "{{ client_role_user_available.json }}"
+  loop: "{{ client_role_user_available.json | flatten }}"
   when: item.name == client_role.role

--- a/roles/3trains_keycloak/tasks/manage_user_roles.yml
+++ b/roles/3trains_keycloak/tasks/manage_user_roles.yml
@@ -1,15 +1,15 @@
 ---
 
-- name: "Get User"
+- name: "Get User {{ user.username }}"
   uri:
     url: "{{ keycloak_url }}/auth/admin/realms/{{ keycloak_realm }}/users?username={{ user.username }}"
-    validate_certs: no
     headers:
+      validate_certs: no
       Authorization: "Bearer {{ keycloak_auth_response.json.access_token }}"
   register: keycloak_user
 
-- name: Manage Client Role Mapping
+- name: "Manage Client Role Mapping for {{ user.username }}"
   include_tasks: manage_user_client_roles.yml
-  loop: "{{ user.client_roles }}"
+  loop: "{{ user.client_roles | flatten }}"
   loop_control:
     loop_var: client_role

--- a/roles/3trains_keycloak/tasks/manage_user_roles.yml
+++ b/roles/3trains_keycloak/tasks/manage_user_roles.yml
@@ -8,6 +8,17 @@
       Authorization: "Bearer {{ keycloak_auth_response.json.access_token }}"
   register: keycloak_user
 
+- name: Refresh keycloak auth token
+  uri:
+    url: "{{ keycloak_url }}/auth/realms/master/protocol/openid-connect/token"
+    method: POST
+    body: "client_id={{ keycloak_auth_client }}&username={{ keycloak_admin_user }}&password={{ keycloak_admin_password }}&grant_type=password"
+    validate_certs: no
+  register: keycloak_auth_response
+  until: keycloak_auth_response.status == 200
+  retries: 5
+  delay: 2
+
 - name: "Manage Client Role Mapping for {{ user.username }}"
   include_tasks: manage_user_client_roles.yml
   loop: "{{ user.client_roles | flatten }}"

--- a/roles/3trains_keycloak/tasks/systemd.yml
+++ b/roles/3trains_keycloak/tasks/systemd.yml
@@ -54,6 +54,8 @@
       - keycloak_service_status is defined
       - keycloak_service_status.stdout is defined
 
+- meta: flush_handlers
+
 - name: Wait until Keycloak becomes active
   uri:
     url: "{{ keycloak_management_url }}/health"

--- a/roles/3trains_keycloak/templates/standalone-rhsso-jdg.xml.j2
+++ b/roles/3trains_keycloak/templates/standalone-rhsso-jdg.xml.j2
@@ -1,0 +1,715 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<server xmlns="urn:jboss:domain:16.0">
+    <extensions>
+        <extension module="org.jboss.as.clustering.infinispan"/>
+        <extension module="org.jboss.as.clustering.jgroups"/>
+        <extension module="org.jboss.as.connector"/>
+        <extension module="org.jboss.as.deployment-scanner"/>
+        <extension module="org.jboss.as.ee"/>
+        <extension module="org.jboss.as.ejb3"/>
+        <extension module="org.jboss.as.jaxrs"/>
+        <extension module="org.jboss.as.jmx"/>
+        <extension module="org.jboss.as.jpa"/>
+        <extension module="org.jboss.as.logging"/>
+        <extension module="org.jboss.as.mail"/>
+        <extension module="org.jboss.as.modcluster"/>
+        <extension module="org.jboss.as.naming"/>
+        <extension module="org.jboss.as.remoting"/>
+        <extension module="org.jboss.as.security"/>
+        <extension module="org.jboss.as.transactions"/>
+        <extension module="org.jboss.as.weld"/>
+        <extension module="org.keycloak.keycloak-server-subsystem"/>
+        <extension module="org.wildfly.extension.bean-validation"/>
+        <extension module="org.wildfly.extension.core-management"/>
+        <extension module="org.wildfly.extension.elytron"/>
+        <extension module="org.wildfly.extension.health"/>
+        <extension module="org.wildfly.extension.io"/>
+        <extension module="org.wildfly.extension.metrics"/>
+        <extension module="org.wildfly.extension.request-controller"/>
+        <extension module="org.wildfly.extension.security.manager"/>
+        <extension module="org.wildfly.extension.undertow"/>
+    </extensions>
+    <management>
+        <security-realms>
+            <security-realm name="ManagementRealm">
+                <authentication>
+                    <local default-user="$local" skip-group-loading="true"/>
+                    <properties path="mgmt-users.properties" relative-to="jboss.server.config.dir"/>
+                </authentication>
+                <authorization map-groups-to-roles="false">
+                    <properties path="mgmt-groups.properties" relative-to="jboss.server.config.dir"/>
+                </authorization>
+            </security-realm>
+            <security-realm name="ApplicationRealm">
+                <server-identities>
+                    <ssl>
+                        <keystore path="application.keystore" relative-to="jboss.server.config.dir" keystore-password="password" alias="server" key-password="password" generate-self-signed-certificate-host="localhost"/>
+                    </ssl>
+                </server-identities>
+                <authentication>
+                    <local default-user="$local" allowed-users="*" skip-group-loading="true"/>
+                    <properties path="application-users.properties" relative-to="jboss.server.config.dir"/>
+                </authentication>
+                <authorization>
+                    <properties path="application-roles.properties" relative-to="jboss.server.config.dir"/>
+                </authorization>
+            </security-realm>
+        </security-realms>
+        <audit-log>
+            <formatters>
+                <json-formatter name="json-formatter"/>
+            </formatters>
+            <handlers>
+                <file-handler name="file" formatter="json-formatter" path="audit-log.log" relative-to="jboss.server.data.dir"/>
+            </handlers>
+            <logger log-boot="true" log-read-only="false" enabled="false">
+                <handlers>
+                    <handler name="file"/>
+                </handlers>
+            </logger>
+        </audit-log>
+        <management-interfaces>
+            <http-interface security-realm="ManagementRealm">
+                <http-upgrade enabled="true"/>
+                <socket-binding http="management-http"/>
+            </http-interface>
+        </management-interfaces>
+        <access-control provider="simple">
+            <role-mapping>
+                <role name="SuperUser">
+                    <include>
+                        <user name="$local"/>
+                    </include>
+                </role>
+            </role-mapping>
+        </access-control>
+    </management>
+    <profile>
+        <subsystem xmlns="urn:jboss:domain:logging:8.0">
+            <console-handler name="CONSOLE">
+                <level name="INFO"/>
+                <formatter>
+                    <named-formatter name="COLOR-PATTERN"/>
+                </formatter>
+            </console-handler>
+            <periodic-rotating-file-handler name="FILE" autoflush="true">
+                <formatter>
+                    <named-formatter name="PATTERN"/>
+                </formatter>
+                <file relative-to="jboss.server.log.dir" path="server.log"/>
+                <suffix value=".yyyy-MM-dd"/>
+                <append value="true"/>
+            </periodic-rotating-file-handler>
+            <logger category="com.arjuna">
+                <level name="WARN"/>
+            </logger>
+            <logger category="io.jaegertracing.Configuration">
+                <level name="WARN"/>
+            </logger>
+            <logger category="org.jboss.as.config">
+                <level name="DEBUG"/>
+            </logger>
+            <logger category="sun.rmi">
+                <level name="WARN"/>
+            </logger>
+            <logger category="org.keycloak.cluster.infinispan">
+                <level name="DEBUG"/>
+            </logger>
+            <logger category="org.keycloak.connections.infinispan">
+                <level name="DEBUG"/>
+            </logger>
+            <logger category="org.keycloak.models.cache.infinispan">
+                <level name="DEBUG"/>
+            </logger>
+            <logger category="org.keycloak.models.sessions.infinispan">
+                <level name="DEBUG"/>
+            </logger>
+            <root-logger>
+                <level name="INFO"/>
+                <handlers>
+                    <handler name="CONSOLE"/>
+                    <handler name="FILE"/>
+                </handlers>
+            </root-logger>
+            <formatter name="PATTERN">
+                <pattern-formatter pattern="%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n"/>
+            </formatter>
+            <formatter name="COLOR-PATTERN">
+                <pattern-formatter pattern="%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n"/>
+            </formatter>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:bean-validation:1.0"/>
+        <subsystem xmlns="urn:jboss:domain:core-management:1.0"/>
+        <subsystem xmlns="urn:jboss:domain:datasources:6.0">
+            <datasources>
+                <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true" statistics-enabled="${wildfly.datasources.statistics-enabled:${wildfly.statistics-enabled:false}}">
+                    <connection-url>jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE</connection-url>
+                    <driver>h2</driver>
+                    <security>
+                        <user-name>sa</user-name>
+                        <password>sa</password>
+                    </security>
+                </datasource>
+                <datasource jndi-name="java:jboss/datasources/KeycloakDS" pool-name="KeycloakDS" enabled="true" use-java-context="true" statistics-enabled="${wildfly.datasources.statistics-enabled:${wildfly.statistics-enabled:false}}">
+{% if keycloak_jdbc.postgres.enabled %}
+                    <connection-url>{{ keycloak_jdbc.postgres.connection_url }}</connection-url>
+                    <driver>{{ keycloak_jdbc.postgres.driver_module_name }}</driver>
+                    <pool>
+                       <max-pool-size>20</max-pool-size>
+                    </pool>
+                    <security>
+                        <user-name>{{ keycloak_jdbc.postgres.db_user }}</user-name>
+                        <password>{{ keycloak_jdbc.postgres.db_password }}</password>
+                    </security>
+{% else %}
+                    <connection-url>jdbc:h2:${jboss.server.data.dir}/keycloak;AUTO_SERVER=TRUE</connection-url>
+                    <driver>h2</driver>
+                    <security>
+                        <user-name>sa</user-name>
+                        <password>sa</password>
+                    </security>
+{% endif %}
+                </datasource>
+                <drivers>
+{% if keycloak_jdbc.postgres.enabled %}
+                    <driver name="{{ keycloak_jdbc.postgres.driver_module_name }}" module="{{ keycloak_jdbc.postgres.driver_module_name }}">
+                         <driver-class>org.postgresql.Driver</driver-class>
+                        <xa-datasource-class>org.postgresql.xa.PGXADataSource</xa-datasource-class>
+                    </driver>
+{% endif %}
+                    <driver name="h2" module="com.h2database.h2">
+                        <xa-datasource-class>org.h2.jdbcx.JdbcDataSource</xa-datasource-class>
+                    </driver>
+                </drivers>
+            </datasources>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:deployment-scanner:2.0">
+            <deployment-scanner path="deployments" relative-to="jboss.server.base.dir" scan-interval="5000" runtime-failure-causes-rollback="${jboss.deployment.scanner.rollback.on.failure:false}"/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:ee:6.0">
+            <spec-descriptor-property-replacement>false</spec-descriptor-property-replacement>
+            <concurrent>
+                <context-services>
+                    <context-service name="default" jndi-name="java:jboss/ee/concurrency/context/default" use-transaction-setup-provider="true"/>
+                </context-services>
+                <managed-thread-factories>
+                    <managed-thread-factory name="default" jndi-name="java:jboss/ee/concurrency/factory/default" context-service="default"/>
+                </managed-thread-factories>
+                <managed-executor-services>
+                    <managed-executor-service name="default" jndi-name="java:jboss/ee/concurrency/executor/default" context-service="default" hung-task-termination-period="0" hung-task-threshold="60000" keepalive-time="5000"/>
+                </managed-executor-services>
+                <managed-scheduled-executor-services>
+                    <managed-scheduled-executor-service name="default" jndi-name="java:jboss/ee/concurrency/scheduler/default" context-service="default" hung-task-termination-period="0" hung-task-threshold="60000" keepalive-time="3000"/>
+                </managed-scheduled-executor-services>
+            </concurrent>
+            <default-bindings context-service="java:jboss/ee/concurrency/context/default" datasource="java:jboss/datasources/ExampleDS" managed-executor-service="java:jboss/ee/concurrency/executor/default" managed-scheduled-executor-service="java:jboss/ee/concurrency/scheduler/default" managed-thread-factory="java:jboss/ee/concurrency/factory/default"/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:ejb3:9.0">
+            <session-bean>
+                <stateless>
+                    <bean-instance-pool-ref pool-name="slsb-strict-max-pool"/>
+                </stateless>
+                <stateful default-access-timeout="5000" cache-ref="simple" passivation-disabled-cache-ref="simple"/>
+                <singleton default-access-timeout="5000"/>
+            </session-bean>
+            <pools>
+                <bean-instance-pools>
+                    <strict-max-pool name="mdb-strict-max-pool" derive-size="from-cpu-count" instance-acquisition-timeout="5" instance-acquisition-timeout-unit="MINUTES"/>
+                    <strict-max-pool name="slsb-strict-max-pool" derive-size="from-worker-pools" instance-acquisition-timeout="5" instance-acquisition-timeout-unit="MINUTES"/>
+                </bean-instance-pools>
+            </pools>
+            <caches>
+                <cache name="simple"/>
+                <cache name="distributable" passivation-store-ref="infinispan" aliases="passivating clustered"/>
+            </caches>
+            <passivation-stores>
+                <passivation-store name="infinispan" cache-container="ejb" max-size="10000"/>
+            </passivation-stores>
+            <async thread-pool-name="default"/>
+            <timer-service thread-pool-name="default" default-data-store="default-file-store">
+                <data-stores>
+                    <file-data-store name="default-file-store" path="timer-service-data" relative-to="jboss.server.data.dir"/>
+                </data-stores>
+            </timer-service>
+            <remote cluster="ejb" connectors="http-remoting-connector" thread-pool-name="default">
+                <channel-creation-options>
+                    <option name="MAX_OUTBOUND_MESSAGES" value="1234" type="remoting"/>
+                </channel-creation-options>
+            </remote>
+            <thread-pools>
+                <thread-pool name="default">
+                    <max-threads count="10"/>
+                    <keepalive-time time="60" unit="seconds"/>
+                </thread-pool>
+            </thread-pools>
+            <default-security-domain value="other"/>
+            <default-missing-method-permissions-deny-access value="true"/>
+            <statistics enabled="${wildfly.ejb3.statistics-enabled:${wildfly.statistics-enabled:false}}"/>
+            <log-system-exceptions value="true"/>
+        </subsystem>
+        <subsystem xmlns="urn:wildfly:elytron:13.0" final-providers="combined-providers" disallowed-providers="OracleUcrypto">
+            <providers>
+                <aggregate-providers name="combined-providers">
+                    <providers name="elytron"/>
+                    <providers name="openssl"/>
+                </aggregate-providers>
+                <provider-loader name="elytron" module="org.wildfly.security.elytron"/>
+                <provider-loader name="openssl" module="org.wildfly.openssl"/>
+            </providers>
+            <audit-logging>
+                <file-audit-log name="local-audit" path="audit.log" relative-to="jboss.server.log.dir" format="JSON"/>
+            </audit-logging>
+            <security-domains>
+                <security-domain name="ApplicationDomain" default-realm="ApplicationRealm" permission-mapper="default-permission-mapper">
+                    <realm name="ApplicationRealm" role-decoder="groups-to-roles"/>
+                    <realm name="local"/>
+                </security-domain>
+                <security-domain name="ManagementDomain" default-realm="ManagementRealm" permission-mapper="default-permission-mapper">
+                    <realm name="ManagementRealm" role-decoder="groups-to-roles"/>
+                    <realm name="local" role-mapper="super-user-mapper"/>
+                </security-domain>
+            </security-domains>
+            <security-realms>
+                <identity-realm name="local" identity="$local"/>
+                <properties-realm name="ApplicationRealm">
+                    <users-properties path="application-users.properties" relative-to="jboss.server.config.dir" digest-realm-name="ApplicationRealm"/>
+                    <groups-properties path="application-roles.properties" relative-to="jboss.server.config.dir"/>
+                </properties-realm>
+                <properties-realm name="ManagementRealm">
+                    <users-properties path="mgmt-users.properties" relative-to="jboss.server.config.dir" digest-realm-name="ManagementRealm"/>
+                    <groups-properties path="mgmt-groups.properties" relative-to="jboss.server.config.dir"/>
+                </properties-realm>
+            </security-realms>
+            <mappers>
+                <simple-permission-mapper name="default-permission-mapper" mapping-mode="first">
+                    <permission-mapping>
+                        <principal name="anonymous"/>
+                        <permission-set name="default-permissions"/>
+                    </permission-mapping>
+                    <permission-mapping match-all="true">
+                        <permission-set name="login-permission"/>
+                        <permission-set name="default-permissions"/>
+                    </permission-mapping>
+                </simple-permission-mapper>
+                <constant-realm-mapper name="local" realm-name="local"/>
+                <simple-role-decoder name="groups-to-roles" attribute="groups"/>
+                <constant-role-mapper name="super-user-mapper">
+                    <role name="SuperUser"/>
+                </constant-role-mapper>
+            </mappers>
+            <permission-sets>
+                <permission-set name="login-permission">
+                    <permission class-name="org.wildfly.security.auth.permission.LoginPermission"/>
+                </permission-set>
+                <permission-set name="default-permissions">
+                    <permission class-name="org.wildfly.extension.batch.jberet.deployment.BatchPermission" module="org.wildfly.extension.batch.jberet" target-name="*"/>
+                    <permission class-name="org.wildfly.transaction.client.RemoteTransactionPermission" module="org.wildfly.transaction.client"/>
+                    <permission class-name="org.jboss.ejb.client.RemoteEJBPermission" module="org.jboss.ejb-client"/>
+                    <permission class-name="org.jboss.ejb.client.RemoteEJBPermission" module="org.jboss.ejb-client"/>
+                </permission-set>
+            </permission-sets>
+            <http>
+                <http-authentication-factory name="management-http-authentication" security-domain="ManagementDomain" http-server-mechanism-factory="global">
+                    <mechanism-configuration>
+                        <mechanism mechanism-name="DIGEST">
+                            <mechanism-realm realm-name="ManagementRealm"/>
+                        </mechanism>
+                    </mechanism-configuration>
+                </http-authentication-factory>
+                <provider-http-server-mechanism-factory name="global"/>
+            </http>
+            <sasl>
+                <sasl-authentication-factory name="application-sasl-authentication" sasl-server-factory="configured" security-domain="ApplicationDomain">
+                    <mechanism-configuration>
+                        <mechanism mechanism-name="JBOSS-LOCAL-USER" realm-mapper="local"/>
+                        <mechanism mechanism-name="DIGEST-MD5">
+                            <mechanism-realm realm-name="ApplicationRealm"/>
+                        </mechanism>
+                    </mechanism-configuration>
+                </sasl-authentication-factory>
+                <sasl-authentication-factory name="management-sasl-authentication" sasl-server-factory="configured" security-domain="ManagementDomain">
+                    <mechanism-configuration>
+                        <mechanism mechanism-name="JBOSS-LOCAL-USER" realm-mapper="local"/>
+                        <mechanism mechanism-name="DIGEST-MD5">
+                            <mechanism-realm realm-name="ManagementRealm"/>
+                        </mechanism>
+                    </mechanism-configuration>
+                </sasl-authentication-factory>
+                <configurable-sasl-server-factory name="configured" sasl-server-factory="elytron">
+                    <properties>
+                        <property name="wildfly.sasl.local-user.default-user" value="$local"/>
+                    </properties>
+                </configurable-sasl-server-factory>
+                <mechanism-provider-filtering-sasl-server-factory name="elytron" sasl-server-factory="global">
+                    <filters>
+                        <filter provider-name="WildFlyElytron"/>
+                    </filters>
+                </mechanism-provider-filtering-sasl-server-factory>
+                <provider-sasl-server-factory name="global"/>
+            </sasl>
+            <tls>
+                <key-stores>
+                    <key-store name="applicationKS">
+                        <credential-reference clear-text="password"/>
+                        <implementation type="JKS"/>
+                        <file path="application.keystore" relative-to="jboss.server.config.dir"/>
+                    </key-store>
+                </key-stores>
+                <key-managers>
+                    <key-manager name="applicationKM" key-store="applicationKS" generate-self-signed-certificate-host="localhost">
+                        <credential-reference clear-text="password"/>
+                    </key-manager>
+                </key-managers>
+                <server-ssl-contexts>
+                    <server-ssl-context name="applicationSSC" key-manager="applicationKM"/>
+                </server-ssl-contexts>
+            </tls>
+        </subsystem>
+        <subsystem xmlns="urn:wildfly:health:1.0" security-enabled="false"/>
+        <subsystem xmlns="urn:jboss:domain:infinispan:12.0">
+            <cache-container name="ejb" default-cache="passivation" aliases="sfsb" modules="org.wildfly.clustering.ejb.infinispan">
+                <local-cache name="passivation">
+                    <locking isolation="REPEATABLE_READ"/>
+                    <transaction mode="BATCH"/>
+                    <file-store passivation="true" purge="false"/>
+                </local-cache>
+            </cache-container>
+            <cache-container name="keycloak" modules="org.keycloak.keycloak-model-infinispan">
+                <transport lock-timeout="60000"/>
+                <local-cache name="realms">
+                    <heap-memory size="10000"/>
+                </local-cache>
+                <local-cache name="users">
+                    <heap-memory size="10000"/>
+                </local-cache>
+                <local-cache name="authenticationSessions"/>
+                {% for cachename in [ "sessions", "offlineSessions", "clientSessions", "offlineClientSessions", "loginFailures", "actionTokens" ] %}
+                <distributed-cache name="{{ cachename }}">
+                    <remote-store cache="{{ cachename }}"
+                                  remote-servers="remote-cache"
+                                  passivation="false"
+                                  fetch-state="false"
+                                  purge="false"
+                                  preload="false"
+                                  shared="true">
+                        <property name="rawValues">true</property>
+                        <property name="marshaller">org.keycloak.cluster.infinispan.KeycloakHotRodMarshallerFactory</property>
+                        <property name="remoteStoreSecurityEnabled">false</property>
+                        <property name="infinispan.client.hotrod.auth_username">{{ keycloak_remotecache.username }}</property>
+                        <property name="infinispan.client.hotrod.auth_password">{{ keycloak_remotecache.password }}</property>
+                        <property name="infinispan.client.hotrod.auth_realm">{{ keycloak_remotecache.realm | default('default') }}</property>
+                        <property name="infinispan.client.hotrod.auth_server_name">{{ keycloak_remotecache.server_name }}</property>
+                        <property name="infinispan.client.hotrod.sasl_mechanism">{{ keycloak_remotecache.sasl_mechanism | default('SCRAM-SHA-512') }}</property>
+                        <property name="infinispan.client.hotrod.use_ssl">false</property>
+                        <property name="infinispan.client.hotrod.trust_store_file_name">{{ keycloak_remotecache.trust_store_path | default('/etc/truststore/truststore.jks') }}</property>
+                        <property name="infinispan.client.hotrod.trust_store_type">JKS</property>
+                        <property name="infinispan.client.hotrod.trust_store_password">{{ keycloak_remotecache.trust_store_password | default("changeme") }}</property>
+                    </remote-store>
+                </distributed-cache>
+                {% endfor %}
+                <replicated-cache name="work">
+                    <remote-store cache="work"
+                                  remote-servers="remote-cache"
+                                  passivation="false"
+                                  fetch-state="false"
+                                  purge="false"
+                                  preload="false"
+                                  shared="true">
+                        <property name="rawValues">true</property>
+                        <property name="marshaller">org.keycloak.cluster.infinispan.KeycloakHotRodMarshallerFactory</property>
+                        <property name="remoteStoreSecurityEnabled">false</property>
+                        <property name="infinispan.client.hotrod.auth_username">{{ keycloak_remotecache.username }}</property>
+                        <property name="infinispan.client.hotrod.auth_password">{{ keycloak_remotecache.password }}</property>
+                        <property name="infinispan.client.hotrod.auth_realm">{{ keycloak_remotecache.realm | default('default') }}</property>
+                        <property name="infinispan.client.hotrod.auth_server_name">{{ keycloak_remotecache.server_name }}</property>
+                        <property name="infinispan.client.hotrod.sasl_mechanism">{{ keycloak_remotecache.sasl_mechanism | default('SCRAM-SHA-512') }}</property>
+                        <property name="infinispan.client.hotrod.use_ssl">false</property>
+                        <property name="infinispan.client.hotrod.trust_store_file_name">{{ keycloak_remotecache.trust_store_path | default('/etc/truststore/truststore.jks') }}</property>
+                        <property name="infinispan.client.hotrod.trust_store_type">JKS</property>
+                        <property name="infinispan.client.hotrod.trust_store_password">{{ keycloak_remotecache.trust_store_password | default("changeme") }}</property>
+                    </remote-store>
+                </replicated-cache>
+                <local-cache name="authorization">
+                    <heap-memory size="10000"/>
+                </local-cache>
+                <local-cache name="keys">
+                    <heap-memory size="1000"/>
+                    <expiration max-idle="3600000"/>
+                </local-cache>
+            </cache-container>
+            <cache-container name="server" default-cache="default" modules="org.wildfly.clustering.server">
+                <local-cache name="default">
+                    <transaction mode="BATCH"/>
+                </local-cache>
+            </cache-container>
+            <cache-container name="web" default-cache="passivation" modules="org.wildfly.clustering.web.infinispan">
+                <local-cache name="passivation">
+                    <locking isolation="REPEATABLE_READ"/>
+                    <transaction mode="BATCH"/>
+                    <file-store passivation="true" purge="false"/>
+                </local-cache>
+                <local-cache name="sso">
+                    <locking isolation="REPEATABLE_READ"/>
+                    <transaction mode="BATCH"/>
+                </local-cache>
+                <local-cache name="routing"/>
+            </cache-container>
+            <cache-container name="hibernate" modules="org.infinispan.hibernate-cache">
+                <local-cache name="entity">
+                    <heap-memory size="10000"/>
+                    <expiration max-idle="100000"/>
+                </local-cache>
+                <local-cache name="local-query">
+                    <heap-memory size="10000"/>
+                    <expiration max-idle="100000"/>
+                </local-cache>
+                <local-cache name="timestamps"/>
+            </cache-container>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:io:3.0">
+            <worker name="default"/>
+            <buffer-pool name="default"/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:jaxrs:2.0"/>
+        <subsystem xmlns="urn:jboss:domain:jca:5.0">
+            <archive-validation enabled="true" fail-on-error="true" fail-on-warn="false"/>
+            <bean-validation enabled="true"/>
+            <default-workmanager>
+                <short-running-threads>
+                    <core-threads count="50"/>
+                    <queue-length count="50"/>
+                    <max-threads count="50"/>
+                    <keepalive-time time="10" unit="seconds"/>
+                </short-running-threads>
+                <long-running-threads>
+                    <core-threads count="50"/>
+                    <queue-length count="50"/>
+                    <max-threads count="50"/>
+                    <keepalive-time time="10" unit="seconds"/>
+                </long-running-threads>
+            </default-workmanager>
+            <cached-connection-manager/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:jgroups:8.0">
+            <channels default="ee">
+                <channel name="ee" stack="tcp" cluster="ejb"/>
+            </channels>
+            <stacks>
+                <stack name="tcp">
+                    <transport site="${jboss.node.name}" type="TCP" socket-binding="jgroups-tcp"/>
+                </stack>
+            </stacks>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:jmx:1.3">
+            <expose-resolved-model/>
+            <expose-expression-model/>
+            <remoting-connector/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:jpa:1.1">
+            <jpa default-extended-persistence-inheritance="DEEP"/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:keycloak-server:1.1">
+            <web-context>auth</web-context>
+            <providers>
+                <provider>
+                    classpath:${jboss.home.dir}/providers/*
+                </provider>
+            </providers>
+            <master-realm-name>master</master-realm-name>
+            <scheduled-task-interval>900</scheduled-task-interval>
+            <theme>
+                <staticMaxAge>2592000</staticMaxAge>
+                <cacheThemes>true</cacheThemes>
+                <cacheTemplates>true</cacheTemplates>
+                <dir>${jboss.home.dir}/themes</dir>
+            </theme>
+            <spi name="eventsStore">
+                <provider name="jpa" enabled="true">
+                    <properties>
+                        <property name="exclude-events" value="[&quot;REFRESH_TOKEN&quot;]"/>
+                    </properties>
+                </provider>
+            </spi>
+            <spi name="userCache">
+                <provider name="default" enabled="true"/>
+            </spi>
+            <spi name="userSessionPersister">
+                <default-provider>jpa</default-provider>
+            </spi>
+            <spi name="timer">
+                <default-provider>basic</default-provider>
+            </spi>
+            <spi name="connectionsHttpClient">
+                <provider name="default" enabled="true"/>
+            </spi>
+            <spi name="connectionsJpa">
+                <provider name="default" enabled="true">
+                    <properties>
+                        <property name="dataSource" value="java:jboss/datasources/KeycloakDS"/>
+                        <property name="initializeEmpty" value="true"/>
+                        <property name="migrationStrategy" value="update"/>
+                        <property name="migrationExport" value="${jboss.home.dir}/keycloak-database-update.sql"/>
+                    </properties>
+                </provider>
+            </spi>
+            <spi name="realmCache">
+                <provider name="default" enabled="true"/>
+            </spi>
+            <spi name="connectionsInfinispan">
+                <default-provider>default</default-provider>
+                <provider name="default" enabled="true">
+                    <properties>
+                        <property name="cacheContainer" value="java:jboss/infinispan/container/keycloak"/>
+                    </properties>
+                </provider>
+            </spi>
+            <spi name="jta-lookup">
+                <default-provider>${keycloak.jta.lookup.provider:jboss}</default-provider>
+                <provider name="jboss" enabled="true"/>
+            </spi>
+            <spi name="publicKeyStorage">
+                <provider name="infinispan" enabled="true">
+                    <properties>
+                        <property name="minTimeBetweenRequests" value="10"/>
+                    </properties>
+                </provider>
+            </spi>
+            <spi name="x509cert-lookup">
+                <default-provider>${keycloak.x509cert.lookup.provider:default}</default-provider>
+                <provider name="default" enabled="true"/>
+            </spi>
+            <spi name="hostname">
+                <default-provider>default</default-provider>
+                <provider name="default" enabled="true">
+                    <properties>
+                        <property name="frontendUrl" value="${keycloak.frontendUrl:}"/>
+                        <property name="forceBackendUrlToFrontendUrl" value="false"/>
+                    </properties>
+                </provider>
+            </spi>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:mail:4.0">
+            <mail-session name="default" jndi-name="java:jboss/mail/Default">
+                <smtp-server outbound-socket-binding-ref="mail-smtp"/>
+            </mail-session>
+        </subsystem>
+        <subsystem xmlns="urn:wildfly:metrics:1.0" security-enabled="false" exposed-subsystems="*" prefix="${wildfly.metrics.prefix:jboss}"/>
+        <subsystem xmlns="urn:jboss:domain:modcluster:5.0">
+            <proxy name="default" advertise-socket="modcluster" listener="ajp" proxies="proxy1">
+                <dynamic-load-provider>
+                    <load-metric type="cpu"/>
+                </dynamic-load-provider>
+            </proxy>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:naming:2.0">
+            <remote-naming/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:remoting:4.0">
+            <http-connector name="http-remoting-connector" connector-ref="default" security-realm="ApplicationRealm"/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:request-controller:1.0"/>
+        <subsystem xmlns="urn:jboss:domain:security:2.0">
+            <security-domains>
+                <security-domain name="other" cache-type="default">
+                    <authentication>
+                        <login-module code="Remoting" flag="optional">
+                            <module-option name="password-stacking" value="useFirstPass"/>
+                        </login-module>
+                        <login-module code="RealmDirect" flag="required">
+                            <module-option name="password-stacking" value="useFirstPass"/>
+                        </login-module>
+                    </authentication>
+                </security-domain>
+                <security-domain name="jboss-web-policy" cache-type="default">
+                    <authorization>
+                        <policy-module code="Delegating" flag="required"/>
+                    </authorization>
+                </security-domain>
+                <security-domain name="jaspitest" cache-type="default">
+                    <authentication-jaspi>
+                        <login-module-stack name="dummy">
+                            <login-module code="Dummy" flag="optional"/>
+                        </login-module-stack>
+                        <auth-module code="Dummy"/>
+                    </authentication-jaspi>
+                </security-domain>
+                <security-domain name="jboss-ejb-policy" cache-type="default">
+                    <authorization>
+                        <policy-module code="Delegating" flag="required"/>
+                    </authorization>
+                </security-domain>
+            </security-domains>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:security-manager:1.0">
+            <deployment-permissions>
+                <maximum-set>
+                    <permission class="java.security.AllPermission"/>
+                </maximum-set>
+            </deployment-permissions>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:transactions:6.0">
+            <core-environment node-identifier="${jboss.tx.node.id:1}">
+                <process-id>
+                    <uuid/>
+                </process-id>
+            </core-environment>
+            <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
+            <coordinator-environment statistics-enabled="${wildfly.transactions.statistics-enabled:${wildfly.statistics-enabled:false}}"/>
+            <object-store path="tx-object-store" relative-to="jboss.server.data.dir"/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:undertow:12.0" default-server="default-server" default-virtual-host="default-host" default-servlet-container="default" default-security-domain="other" statistics-enabled="${wildfly.undertow.statistics-enabled:${wildfly.statistics-enabled:false}}">
+            <buffer-cache name="default"/>
+            <server name="default-server">
+                <ajp-listener name="ajp" socket-binding="ajp"/>
+                <http-listener name="default" socket-binding="http" redirect-socket="https" enable-http2="true" proxy-address-forwarding="true"/>
+                <https-listener name="https" socket-binding="https" security-realm="ApplicationRealm" enable-http2="true"/>
+                <host name="default-host" alias="localhost">
+                    <location name="/" handler="welcome-content"/>
+                    <http-invoker security-realm="ApplicationRealm"/>
+                    <filter-ref name="proxy-peer"/>
+                </host>
+            </server>
+            <servlet-container name="default">
+                <jsp-config/>
+                <websockets/>
+            </servlet-container>
+            <handlers>
+                <file name="welcome-content" path="${jboss.home.dir}/welcome-content"/>
+            </handlers>
+            <filters>
+                <filter name="proxy-peer" module="io.undertow.core"
+                        class-name="io.undertow.server.handlers.ProxyPeerAddressHandler"/>
+            </filters>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:weld:4.0"/>
+    </profile>
+    <interfaces>
+        <interface name="management">
+            <inet-address value="${jboss.bind.address.management:127.0.0.1}"/>
+        </interface>
+        <interface name="public">
+            <inet-address value="${jboss.bind.address:127.0.0.1}"/>
+        </interface>
+    </interfaces>
+    <socket-binding-group name="standard-sockets" default-interface="public" port-offset="${jboss.socket.binding.port-offset:0}">
+        <socket-binding name="ajp" port="${jboss.ajp.port:8009}"/>
+        <socket-binding name="http" port="${jboss.http.port:8080}"/>
+        <socket-binding name="https" port="${jboss.https.port:8443}"/>
+        <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>
+        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9993}"/>
+        <socket-binding name="jgroups-tcp" interface="management" port="7600"/>
+        <socket-binding name="modcluster" multicast-address="${jboss.modcluster.multicast.address:224.0.1.105}" multicast-port="23364"/>
+        <socket-binding name="txn-recovery-environment" port="4712"/>
+        <socket-binding name="txn-status-manager" port="4713"/>
+        <outbound-socket-binding name="mail-smtp">
+            <remote-destination host="${jboss.mail.server.host:localhost}" port="${jboss.mail.server.port:25}"/>
+        </outbound-socket-binding>
+        <outbound-socket-binding name="proxy1">
+            <remote-destination host="{{ (groups['jbcs'][0] if groups['jbcs'] | length > 0 else 'localhost') }}" port="6666"/>
+        </outbound-socket-binding>
+        <outbound-socket-binding name="remote-cache">
+            <remote-destination host="{{ (groups['jdg'][0] if groups['jdg'] | length > 0 else 'localhost') }}" port="${remote.cache.port:11222}"/>
+        </outbound-socket-binding>
+    </socket-binding-group>
+</server>

--- a/roles/3trains_postgresql/defaults/main.yml
+++ b/roles/3trains_postgresql/defaults/main.yml
@@ -7,6 +7,9 @@ pgsql:
     - python3-psycopg2
     - postgresql-server
   db:
-    name: "{{ postgres.db_name | default('default_db') }}"
-    user: "{{ postgres.user.name | default('db_user') }}"
-    password: "{{ postgres.user.password | default('db_password') }}"
+    - name: "{{ postgres.db_name | default('default_db') }}"
+      user: "{{ postgres.user.name | default('db_user') }}"
+      password: "{{ postgres.user.password | default('db_password') }}"
+    - name: "keycloak"
+      user: "keycloak-user"
+      password: "keycloak-pass"

--- a/roles/3trains_postgresql/tasks/main.yml
+++ b/roles/3trains_postgresql/tasks/main.yml
@@ -63,14 +63,16 @@
 
 - name: "Create database {{ pgsql.db.name }}"
   community.postgresql.postgresql_db:
-    name: "{{ pgsql.db.name }}"
+    name: "{{ item.name }}"
     encoding: UTF-8
     template: 'template0'
+  with_items: "{{ pgsql.db }}"
 
 - name: "Create user for database"
   community.postgresql.postgresql_user:
-    db: "{{ pgsql.db.name }}"
-    name: "{{ pgsql.db.user }}"
-    password: "{{ pgsql.db.user }}"
+    db: "{{ item.name }}"
+    name: "{{ item.user }}"
+    password: "{{ item.password }}"
     priv: ALL
     state: present
+  with_items: "{{ pgsql.db }}"

--- a/roles/3trains_postgresql/templates/pg_hba.conf
+++ b/roles/3trains_postgresql/templates/pg_hba.conf
@@ -84,6 +84,9 @@ host    all             all             127.0.0.1/32            trust
 {% if groups['wildfly'] is defined and groups['wildfly'] | length > 0 %}{% for w in groups['wildfly'] %}
 host    all             all             {{ w }}                   trust
 {% endfor %}{% endif %}
+{% if groups['keycloak'] is defined and groups['keycloak'] | length > 0 %}
+host    keycloak             all             samenet                   trust
+{% endif %}
 # IPv6 local connections:
 host    all             all             ::1/128                 trust
 # Allow replication connections from localhost, by a user with the

--- a/roles/3trains_wildfly/defaults/main.yml
+++ b/roles/3trains_wildfly/defaults/main.yml
@@ -61,5 +61,7 @@ keycloak_auth_client: admin-cli
 keycloak_admin_user: admin
 keycloak_admin_password: "redhat1!"
 keycloak_realm: 3trains
-keycloak_url: "{{ keycloak_3trains_url | default('http://localhost:8080') }}"
+keycloak_url: "{{ keycloak_3trains_url | default('http://keycloak-0:8080') }}"
+keycloak_redirect_url: "{{ keycloak_3trains_redirect_url | default('https://jbcs-0') }}"
 keycloak_client: 3trains
+keycloak_disable_trust_manager: True

--- a/roles/3trains_wildfly/tasks/jcliff-with-keycloak.yml
+++ b/roles/3trains_wildfly/tasks/jcliff-with-keycloak.yml
@@ -37,12 +37,13 @@
           - secure_deployment:
               - deployment_name: "{{ secure_deployment_name }}"
                 realm: "{{ keycloak_realm }}"
-                auth_server_url: "{{ keycloak_url }}/auth/"
+                auth_server_url: "{{ keycloak_redirect_url }}/auth/"
                 ssl_required: EXTERNAL
                 resource: "{{ keycloak_client }}"
                 credential: "{{ keycloak_client_secret_response.json.value | default(omit) }}"
                 verify_token_audience: true
                 use_resource_role_mappings: true
+                disable_trust_manager: {{ keycloak_disable_trust_manager | default(false) }}
       - modcluster:
           proxy:
             - name: default

--- a/roles/3trains_wildfly/tasks/jcliff-with-keycloak.yml
+++ b/roles/3trains_wildfly/tasks/jcliff-with-keycloak.yml
@@ -43,7 +43,7 @@
                 credential: "{{ keycloak_client_secret_response.json.value | default(omit) }}"
                 verify_token_audience: true
                 use_resource_role_mappings: true
-                disable_trust_manager: {{ keycloak_disable_trust_manager | default(false) }}
+                disable_trust_manager: "{{ keycloak_disable_trust_manager | default(false) }}"
       - modcluster:
           proxy:
             - name: default


### PR DESCRIPTION
- keycloak creates a postgresDS now (to allow ha)
- jdg: allow to initialize keycloak caches (hotrod connector, auth but no ssl)
- keycloak: allow to declare remote operation for cache in jdg (via hotrod)
- the demo still has a single keycloak node and a single jdd now, with ha operation enabled