### PR TITLE
Last fixups

### DIFF
--- a/collections/requirements.yml
+++ b/collections/requirements.yml
@@ -5,7 +5,7 @@ collections:
   - name: middleware_automation.redhat_csp_download
     version: ">=1.2.1"
   - name: middleware_automation.infinispan
-    version: ">=0.0.11"
+    version: ">=0.0.12"
   - name: middleware_automation.keycloak
     version: ">=0.1.2"
   - name: community.general

--- a/inventory/localhost
+++ b/inventory/localhost
@@ -1,22 +1,21 @@
 # Placeholder Group
 [threetrains]
 
-# Wildfly Group
+[jbcs]
+jbcs-0 ansible_connection=local
+
 [wildfly]
-localhost ansible_connection=local
+wfly-0 ansible_connection=local
 
 # Keycloak Group
 [keycloak]
-localhost ansible_connection=local
-
-[jbcs]
-localhost ansible_connection=local
-
-[pgsql]
-localhost ansible_connection=local
+keycloak-0 ansible_connection=local
 
 [jdg]
-localhost ansible_connection=local
+jdg-0 ansible_connection=local
+
+[pgsql]
+pgsql-0 ansible_connection=local
 
 [threetrains:children]
 wildfly

--- a/playbooks/preconds.yml
+++ b/playbooks/preconds.yml
@@ -27,3 +27,17 @@
         - rhn_username is defined
         - rhn_password is defined
         - ansible_facts['virtualization_type'] != "oci"
+
+
+    - name: "Ensure that OS has the required packages installed"
+      include_role:
+        name: 3trains_fastpackages
+      vars:
+        packages_list:
+          - yum-utils
+          - hostname
+          - net-tools
+          - iproute
+          - bind-utils
+          - glibc-locale-source
+          - glibc-langpack-en

--- a/roles/3trains_wildfly/tasks/appserver.yml
+++ b/roles/3trains_wildfly/tasks/appserver.yml
@@ -20,8 +20,6 @@
 
 - name: "Install RHSSO Extension on instance {{ instance_name }}"
   include_tasks: keycloak/keycloak-extension-install.yml
-  when:
-    - enable_rhsso
 
 - name: "Deploy app on instance {{ instance_name }}"
   include_tasks: fine-tuned-wildfly.yml


### PR DESCRIPTION
@guidograzioli note that the enable_rhsso is not needed, no matter what jcliff has the keycloak config and will need to have keycloak install to run it. (there used to be to be two jcliff config, one with keycloak, one without, but it was to cumbersome to maintain).